### PR TITLE
Fix empty encoding in rectified image header

### DIFF
--- a/catkin_ws/src/arena_camera/src/arena_camera_node.cpp
+++ b/catkin_ws/src/arena_camera/src/arena_camera_node.cpp
@@ -678,7 +678,7 @@ void ArenaCameraNode::setupRectification()
     cv_bridge_img_rect_ = new cv_bridge::CvImage();
   }
   cv_bridge_img_rect_->header = img_raw_msg_.header;
-  cv_bridge_img_rect_->encoding = img_raw_msg_.encoding;
+  cv_bridge_img_rect_->encoding = currentROSEncoding();
 }
 
 struct CameraPublisherImpl


### PR DESCRIPTION
In `ArenaCameraNode::setupRectification` method `cv_bridge_img_rect_->encoding` is given the value of `img_raw_msg_.encoding` but at that time the raw msg encoding value is empty since in `ArenaCameraNode::startGrabbing` it is given value ( `img_raw_msg_.encoding = currentROSEncoding();` ) after `ArenaCameraNode::setupRectification` runs so the resulting encoding in `cv_bridge_img_rect_` is empty and the `/arena_camera_node/image_rect` topic is broadcasted with empty `encoding` in the messages.

Getting the encoding of the rectified images by calling `currentROSEncoding` fixes the problem.