### PR TITLE
Fix empty frame_id in rectified image header

### DIFF
--- a/catkin_ws/src/arena_camera/src/arena_camera_node.cpp
+++ b/catkin_ws/src/arena_camera/src/arena_camera_node.cpp
@@ -678,6 +678,7 @@ void ArenaCameraNode::setupRectification()
     cv_bridge_img_rect_ = new cv_bridge::CvImage();
   }
   cv_bridge_img_rect_->header = img_raw_msg_.header;
+  cv_bridge_img_rect_->header.frame_id = arena_camera_parameter_set_.cameraFrame();
   cv_bridge_img_rect_->encoding = img_raw_msg_.encoding;
 }
 


### PR DESCRIPTION
At the time of copying header from `img_raw_msg_` the `header` is empty since  `img_raw_msg_` parameter values don't get initialized until after the ones of `cv_bridge_img_rect_`.